### PR TITLE
In progress changes for Spreedly SDK

### DIFF
--- a/CocoaSample/BankAccountFormViewController.swift
+++ b/CocoaSample/BankAccountFormViewController.swift
@@ -72,7 +72,7 @@ extension BankAccountFormViewController: SecureFormDelegate {
             success transaction: Transaction
     ) {
         let token = transaction.paymentMethod?.token ?? "empty"
-        print("My payment token is \(token)")
+        NSLog("My payment token is \(token)")
 
         displayAlert(message: "Token: \(token)", title: "Success")
     }

--- a/CocoaSample/CreditCardFormViewController.swift
+++ b/CocoaSample/CreditCardFormViewController.swift
@@ -59,7 +59,7 @@ extension CreditCardFormViewController: SecureFormDelegate {
             success transaction: Transaction
     ) {
         let token = transaction.paymentMethod?.token ?? "empty"
-        print("My payment token is \(token)")
+        NSLog("My payment token is \(token)")
 
         displayAlert(message: "Token: \(token)", title: "Success")
 

--- a/CocoaSample/ViewController.swift
+++ b/CocoaSample/ViewController.swift
@@ -29,7 +29,7 @@ extension ViewController {
             PaymentMethodItem(type: .creditCard, description: "Mastercard 1111", token: "abc456")
         ]
         builder.didSelectPaymentMethod = { item in
-            print("Payment method selected token: \(item.token)")
+            NSLog("Payment method selected token: \(item.token)")
             self.navigationController?.popToViewController(self, animated: true)
         }
 
@@ -130,7 +130,7 @@ extension ViewController {
             PaymentMethodItem(type: .creditCard, description: "MC 4444", token: "abc456")
         ]
         builder.didSelectPaymentMethod = { item in
-            print("Payment method selected token: \(item.token)")
+            NSLog("Payment method selected token: \(item.token)")
             self.dismiss(animated: true)
         }
         builder.defaultCreditCardInfo = {

--- a/IntegrationTests/Internal/ApplePayTests.swift
+++ b/IntegrationTests/Internal/ApplePayTests.swift
@@ -17,7 +17,7 @@ class ApplePayTests: XCTestCase {
         let promise = client.createPaymentMethodFrom(applePay: info)
 
         let transaction = try promise.assertResult(self)
-        let result = transaction.applePay!
+        let result = try XCTUnwrap(transaction.applePay)
 
         CreditCardTests.assertPaymentMethodFieldsPopulate(result: result, info: info, type: .applePay)
         self.assertCardFieldsPopulate(result: result, info: info)
@@ -30,7 +30,7 @@ class ApplePayTests: XCTestCase {
         info.lastName = "Dog"
         info.testCardNumber = Helpers.testCardNumber
         info.company = "LSGD Partners"
-
+        
         let billing = Address()
         billing.address1 = "123 Fake St"
         billing.address2 = "Suite #200"
@@ -56,7 +56,7 @@ class ApplePayTests: XCTestCase {
         let promise = client.createPaymentMethodFrom(applePay: info)
 
         let transaction = try promise.assertResult(self)
-        let result = transaction.applePay!
+        let result = try XCTUnwrap(transaction.applePay)
 
         CreditCardTests.assertPaymentMethodFieldsPopulate(result: result, info: info, type: .applePay)
         self.assertCardFieldsPopulate(result: result, info: info)

--- a/Spreedly/Client.swift
+++ b/Spreedly/Client.swift
@@ -18,7 +18,7 @@ public protocol SpreedlyClient {
     
     var config: ClientConfiguration { get }
     
-    func getPlatformDataLocal() -> String
+    func getPlatformDataLocal() throws -> String
 }
 
 public enum SpreedlySecurityError: Error {

--- a/Spreedly/ClientConfiguration.swift
+++ b/Spreedly/ClientConfiguration.swift
@@ -54,4 +54,5 @@ public enum ClientError: Int, Error {
     case noSpreedlyCredentials
     case parseError
     case invalidRequestData
+    case encodingError
 }

--- a/Spreedly/ClientConfiguration.swift
+++ b/Spreedly/ClientConfiguration.swift
@@ -55,4 +55,5 @@ public enum ClientError: Int, Error {
     case parseError
     case invalidRequestData
     case encodingError
+    case networkError
 }

--- a/Spreedly/ClientFactory.swift
+++ b/Spreedly/ClientFactory.swift
@@ -20,8 +20,4 @@ public class ClientFactory: NSObject {
     public static func _objCCreate(with config: ClientConfiguration) -> _ObjCClient { // swiftlint:disable:this identifier_name line_length
         SpreedlyClientImpl(with: config)
     }
-    
-    public static func getPlatformData() -> String {
-        SpreedlyClientImpl.getPlatformData()
-    }
 }

--- a/Spreedly/Internal/JSON.swift
+++ b/Spreedly/Internal/JSON.swift
@@ -11,7 +11,7 @@ enum JSONError: Error, Equatable {
 }
 
 extension Data {
-    func decodeJson() throws -> [String: Any] {
+    func spr_decodeJson() throws -> [String: Any] {
         guard let json = try? JSONSerialization.jsonObject(with: self) as? [String: Any] else {
             throw JSONError.expectedObject
         }

--- a/Spreedly/Internal/JSON.swift
+++ b/Spreedly/Internal/JSON.swift
@@ -21,7 +21,7 @@ extension Data {
 
 extension Dictionary where Key == String, Value == Any {
 
-    func encodeJson() throws -> Data {
+    func spr_encodeJson() throws -> Data {
         try JSONSerialization.data(withJSONObject: self)
     }
 

--- a/Spreedly/Internal/SpreedlyClientImpl.swift
+++ b/Spreedly/Internal/SpreedlyClientImpl.swift
@@ -83,7 +83,7 @@ class SpreedlyClientImpl: NSObject, SpreedlyClient {
 
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"
-            urlRequest.httpBody = try? request.encodeJson()
+            urlRequest.httpBody = try? request.spr_encodeJson()
             guard urlRequest.httpBody != nil else {
                 source.handleError(error: .invalidRequestData)
                 return
@@ -119,7 +119,7 @@ class SpreedlyClientImpl: NSObject, SpreedlyClient {
             }
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"
-            urlRequest.httpBody = try? request.encodeJson()
+            urlRequest.httpBody = try? request.spr_encodeJson()
             guard urlRequest.httpBody != nil else {
                 source.handleError(error: .invalidRequestData)
                 return
@@ -188,7 +188,7 @@ class SpreedlyClientImpl: NSObject, SpreedlyClient {
             ] as [String : Any],
         ] as [String : Any]
         NSLog("\(data)")
-        guard let encodedData = try? data.encodeJson().base64EncodedString(options: [])
+        guard let encodedData = try? data.spr_encodeJson().base64EncodedString(options: [])
         else { throw ClientError.encodingError }
 
         return encodedData

--- a/Spreedly/Models/ApplePayInfo.swift
+++ b/Spreedly/Models/ApplePayInfo.swift
@@ -31,7 +31,7 @@ public class ApplePayInfo: PaymentMethodInfo {
     internal override func toJson() throws -> [String: Any] {
         var result = [String: Any]()
 
-        result["payment_data"] = try paymentToken.decodeJson()
+        result["payment_data"] = try paymentToken.spr_decodeJson()
         result.maybeSet("test_card_number", testCardNumber)
         return result
     }

--- a/Spreedly/Models/CardBrand.swift
+++ b/Spreedly/Models/CardBrand.swift
@@ -72,125 +72,125 @@ let brandData: [CardBrand: BrandParameters] = [
             max: 16,
             spreedlyType: .alelo,
             detect: {
-                $0.bin(length: 6, in: CardRanges.alelo)
+                $0.isValidBIN(length: 6, in: CardRanges.alelo)
             }
     ),
     .amex: BrandParameters(
             max: 15,
             spreedlyType: .amex,
             detect: {
-                $0.bin(beginning: CardRanges.amex)
+                $0.isValidBIN(beginning: CardRanges.amex)
             }
     ),
     .cabal: BrandParameters(
             max: 16,
             spreedlyType: .cabal,
             detect: {
-                $0.bin(length: 8, in: CardRanges.cabal)
+                $0.isValidBIN(length: 8, in: CardRanges.cabal)
             }
     ),
     .carnet: BrandParameters(
             max: 16,
             spreedlyType: .carnet,
             detect: {
-                $0.bin(length: 6, in: CardRanges.carnet) || $0.bin(beginning: CardRanges.carnetBins)
+                $0.isValidBIN(length: 6, in: CardRanges.carnet) || $0.isValidBIN(beginning: CardRanges.carnetBins)
             }
     ),
     .dankort: BrandParameters(
             max: 16,
             spreedlyType: .dankort,
             detect: {
-                $0.bin(beginning: CardRanges.dankort)
+                $0.isValidBIN(beginning: CardRanges.dankort)
             }
     ),
     .dinersClub: BrandParameters(
             max: 19,
             spreedlyType: .dinersClub,
             detect: {
-                $0.bin(length: 3, in: CardRanges.dinersClub)
+                $0.isValidBIN(length: 3, in: CardRanges.dinersClub)
             }
     ),
     .discover: BrandParameters(
             max: 19,
             spreedlyType: .discover,
             detect: {
-                $0.bin(length: 6, in: CardRanges.discover)
+                $0.isValidBIN(length: 6, in: CardRanges.discover)
             }
     ),
     .elo: BrandParameters(
             max: 16,
             spreedlyType: .elo,
             detect: {
-                $0.bin(length: 6, in: CardRanges.elo)
+                $0.isValidBIN(length: 6, in: CardRanges.elo)
             }
     ),
     .forbrubsforeningen: BrandParameters(
             max: 16,
             spreedlyType: .forbrubsforeningen,
             detect: {
-                $0.bin(beginning: CardRanges.forbrubsforeningen)
+                $0.isValidBIN(beginning: CardRanges.forbrubsforeningen)
             }
     ),
     .jcb: BrandParameters(
             max: 16,
             spreedlyType: .jcb,
             detect: {
-                $0.bin(length: 4, in: CardRanges.jcb)
+                $0.isValidBIN(length: 4, in: CardRanges.jcb)
             }
     ),
     .maestro: BrandParameters(
             max: 19,
             spreedlyType: .maestro,
             detect: {
-                $0.bin(length: 6, in: CardRanges.maestro)
+                $0.isValidBIN(length: 6, in: CardRanges.maestro)
             }
     ),
     .mastercard: BrandParameters(
             max: 16,
             spreedlyType: .mastercard,
             detect: {
-                $0.bin(length: 6, in: CardRanges.mastercard)
+                $0.isValidBIN(length: 6, in: CardRanges.mastercard)
             }
     ),
     .naranja: BrandParameters(
             max: 16,
             spreedlyType: .naranja,
             detect: {
-                $0.bin(length: 6, in: CardRanges.naranja)
+                $0.isValidBIN(length: 6, in: CardRanges.naranja)
             }
     ),
     .sodexo: BrandParameters(
             max: 16,
             spreedlyType: .sodexo,
             detect: {
-                $0.bin(beginning: CardRanges.sodexo)
+                $0.isValidBIN(beginning: CardRanges.sodexo)
             }
     ),
     .unionpay: BrandParameters(
             max: 19,
             spreedlyType: .unionpay,
             detect: {
-                $0.bin(length: 8, in: CardRanges.unionPay)
+                $0.isValidBIN(length: 8, in: CardRanges.unionPay)
             }
     ),
     .visa: BrandParameters(
             max: 19,
             spreedlyType: .visa,
             detect: {
-                $0.bin(beginning: CardRanges.visa)
+                $0.isValidBIN(beginning: CardRanges.visa)
             }
     ),
     .vr: BrandParameters(
             max: 16,
             spreedlyType: .vr,
             detect: {
-                $0.bin(beginning: CardRanges.vr)
+                $0.isValidBIN(beginning: CardRanges.vr)
             }
     )
 ]
 
 fileprivate extension String {
-    func bin(length: Int, in binRanges: [ClosedRange<Int>]) -> Bool {
+    func isValidBIN(length: Int, in binRanges: [ClosedRange<Int>]) -> Bool {
         let cleaned = self.onlyNumbers()
         guard cleaned.count >= length,
               let bin = Int(cleaned.prefix(length)) else {
@@ -201,7 +201,7 @@ fileprivate extension String {
         }
     }
 
-    func bin(beginning bins: [String]) -> Bool {
+    func isValidBIN(beginning bins: [String]) -> Bool {
         let cleaned = self.onlyNumbers()
 
         return bins.contains(where: { bin in

--- a/Spreedly/Models/CardRanges.swift
+++ b/Spreedly/Models/CardRanges.swift
@@ -59,17 +59,17 @@ class CardRanges {
 
     // http://www.barclaycard.co.uk/business/files/bin_rules.pdf
     static let electron = [
-        400115.range,
+        400115.spr_singleDigitRange,
         400837...400839,
         412921...412923,
-        417935.range,
+        417935.spr_singleDigitRange,
         419740...419741,
         419773...419775,
-        424519.range,
+        424519.spr_singleDigitRange,
         424962...424963,
-        437860.range,
-        444000.range,
-        459472.range,
+        437860.spr_singleDigitRange,
+        444000.spr_singleDigitRange,
+        459472.spr_singleDigitRange,
         484406...484411,
         484413...484414,
         484418...484418,
@@ -101,8 +101,8 @@ class CardRanges {
 
     // https://www.mastercard.us/content/dam/mccom/global/documents/mastercard-rules.pdf, page 73
     static let maestro = [
-        500033.range,
-        581149.range,
+        500033.spr_singleDigitRange,
+        581149.spr_singleDigitRange,
         561200...561269,
         561271...561299,
         561320...561356,
@@ -162,7 +162,7 @@ class CardRanges {
 }
 
 extension Int {
-    var range: ClosedRange<Int> {
+    var spr_singleDigitRange: ClosedRange<Int> {
         self...self
     }
 }

--- a/Spreedly/Models/CardRanges.swift
+++ b/Spreedly/Models/CardRanges.swift
@@ -40,9 +40,10 @@ class CardRanges {
     ]
 
     static let dinersClub16Digit = [
-        300...305,
+        300...305, // per this site, these are technically part of 14 digit. https://www.bincodes.com/bin-list/
         380...389
     ]
+    // there are 2 15 digit values which currently fail for Diner's club: 2014, 2149
 
     static let dinersClub14Digit = [
         360...369

--- a/Spreedly/Models/Results.swift
+++ b/Spreedly/Models/Results.swift
@@ -58,10 +58,10 @@ public enum _ObjCPaymentMethodType: Int { // swiftlint:disable:this type_name
     }
 }
 
+/// definitions of the error keys can be found here: https://docs.spreedly.com/reference/iframe/v1/events/#arguments
+/// but attribute values are not listed
 @objc(SPRError)
 public class SpreedlyError: NSObject {
-    // definitions of the error keys can be found here: https://docs.spreedly.com/reference/iframe/v1/events/#arguments
-    // but attribute values are not listed
     @objc public let key: String
     @objc public let message: String
     @objc public let attribute: String?

--- a/Spreedly/Models/Results.swift
+++ b/Spreedly/Models/Results.swift
@@ -60,6 +60,8 @@ public enum _ObjCPaymentMethodType: Int { // swiftlint:disable:this type_name
 
 @objc(SPRError)
 public class SpreedlyError: NSObject {
+    // definitions of the error keys can be found here: https://docs.spreedly.com/reference/iframe/v1/events/#arguments
+    // but attribute values are not listed
     @objc public let key: String
     @objc public let message: String
     @objc public let attribute: String?

--- a/Spreedly/Models/Transaction.swift
+++ b/Spreedly/Models/Transaction.swift
@@ -73,7 +73,7 @@ public class Transaction: NSObject {
     }
 
     static func unwrap(from data: Data) throws -> Transaction {
-        let json = try data.decodeJson()
+        let json = try data.spr_decodeJson()
         if json.keys.contains("transaction") {
             return Transaction(from: try json.object(for: "transaction"))
         }

--- a/Spreedly/Models/Transaction.swift
+++ b/Spreedly/Models/Transaction.swift
@@ -147,7 +147,12 @@ public class SingleTransaction: NSObject { // swiftlint:disable:this type_name
     }
 
     /// Subscribes a success and error handler for this transaction.
-    @objc public func subscribe(onSuccess: ((Transaction) -> Void)?, onError: ((ClientError) -> Void)? = nil) {
+    public func subscribe(onSuccess: ((Transaction) -> Void)?, onError: ((ClientError) -> Void)? = nil) {
         source.subscribe(onSuccess: onSuccess, onError: onError)
     }
+
+    @objc public func subscribe(onSuccess: ((Transaction) -> Void)?, onError: ((Error) -> Void)? = nil) {
+        source.subscribe(onSuccess: onSuccess, onError: onError)
+    }
+
 }

--- a/Spreedly/SpreedlySecureOpaqueString.swift
+++ b/Spreedly/SpreedlySecureOpaqueString.swift
@@ -48,6 +48,16 @@ class SpreedlySecureOpaqueStringImpl: NSObject, SpreedlySecureOpaqueString {
     internal func internalToString() -> String {
         String(data)
     }
+
+    // ensure that default implementation does not change and expose data
+    override var description: String {
+        return String(format: "%p", self)
+    }
+
+    // ensure that default implementation does not change and expose data
+    override var debugDescription: String {
+        return String(format: "%p", self)
+    }
 }
 
 extension SpreedlySecureOpaqueStringImpl: Encodable {

--- a/SpreedlyCocoa/Express/ExpressBuilder.swift
+++ b/SpreedlyCocoa/Express/ExpressBuilder.swift
@@ -19,7 +19,7 @@ import Spreedly
 /// ```swift
 /// var builder = ExpressBuilder()
 /// builder.didSelectPaymentMethod = { item in
-///     print("User wants to use a payment method with token: \(item.token)")
+///     NSLog("User wants to use a payment method with token: \(item.token)")
 /// }
 /// let controller = builder.buildViewController()
 /// navigationController?.show(controller, sender: self)

--- a/UnitTests/BankAccountTests.swift
+++ b/UnitTests/BankAccountTests.swift
@@ -25,7 +25,7 @@ class BankAccountInfoTests: XCTestCase {
                              "bank_account_type" : "checking",
                              "bank_account_holder_type" : "personal"
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -48,7 +48,7 @@ class BankAccountInfoTests: XCTestCase {
                              "bank_account_type" : "checking",
                              "bank_account_holder_type" : "personal"
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }

--- a/UnitTests/CreditCardTests.swift
+++ b/UnitTests/CreditCardTests.swift
@@ -31,7 +31,7 @@ class CreditCardInfoTests: XCTestCase {
                              "verification_value" : "919",
                              "year" : 2029
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -52,7 +52,7 @@ class CreditCardInfoTests: XCTestCase {
                              "verification_value" : "919",
                              "year" : 2029
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -74,7 +74,7 @@ class CreditCardInfoTests: XCTestCase {
                              "verification_value" : "919",
                              "year" : 2029
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }
@@ -90,7 +90,7 @@ class CreditCardInfoTests: XCTestCase {
         creditCard.allowBlankDate = true
 
         let json = try creditCard.toJson()
-        try print(String(data: json.encodeJson(), encoding: .utf8)!)
+        try NSLog(String(data: json.encodeJson(), encoding: .utf8)!)
 
         let expected = try """
                            {
@@ -99,7 +99,7 @@ class CreditCardInfoTests: XCTestCase {
                              "number" : "4111111111111111",
                              "verification_value" : "919",
                            }
-                           """.data(using: .utf8)!.decodeJson()
+                           """.data(using: .utf8)!.spr_decodeJson()
 
         XCTAssertEqual(expected as NSObject, json as NSObject)
     }

--- a/UnitTests/CreditCardTests.swift
+++ b/UnitTests/CreditCardTests.swift
@@ -90,7 +90,7 @@ class CreditCardInfoTests: XCTestCase {
         creditCard.allowBlankDate = true
 
         let json = try creditCard.toJson()
-        try NSLog(String(data: json.encodeJson(), encoding: .utf8)!)
+        try NSLog(String(data: json.spr_encodeJson(), encoding: .utf8)!)
 
         let expected = try """
                            {

--- a/UnitTests/JSONExtensionsTests.swift
+++ b/UnitTests/JSONExtensionsTests.swift
@@ -11,7 +11,7 @@ class DecodeJsonTests: XCTestCase {
     func testDecodeJsonWhenNotJsonShouldThrow() {
         let notJson = "<ul><li>list item</li></ul>"
         let data = notJson.data(using: .utf8)!
-        XCTAssertThrowsError(try data.decodeJson()) { error in
+        XCTAssertThrowsError(try data.spr_decodeJson()) { error in
             XCTAssertEqual(error as? JSONError, .expectedObject)
         }
     }
@@ -21,7 +21,7 @@ class DecodeJsonTests: XCTestCase {
                         "I'm just a string"
                         """
         let data = validJson.data(using: .utf8)!
-        XCTAssertThrowsError(try data.decodeJson()) { error in
+        XCTAssertThrowsError(try data.spr_decodeJson()) { error in
             XCTAssertEqual(error as? JSONError, .expectedObject)
         }
     }
@@ -31,7 +31,7 @@ class DecodeJsonTests: XCTestCase {
                         {"key": "value"}
                         """
         let data = validJson.data(using: .utf8)!
-        let decodedObject = try data.decodeJson()
+        let decodedObject = try data.spr_decodeJson()
         XCTAssertEqual("value", try decodedObject.string(for: "key"))
     }
 }
@@ -52,7 +52,7 @@ let json = try! """
                     "int": 42,
                     "stringInt": "9001"
                 }
-                """.data(using: .utf8)!.decodeJson()
+                """.data(using: .utf8)!.spr_decodeJson()
 
 class ObjectTests: XCTestCase {
     func testWhenMissingShouldThrow() {


### PR DESCRIPTION
1. removed forced unwrapping in SDK
1. updated `getPlatformData`
1. updated `Base64EncodingOptions`
1. prefixed one `Foundation` extension method
1. added timeout to `URLSession`
1. replaced `print` with `NSLog`
1. synchronize array access in Transaction.swift 
1. lazily instantiate platformData`
1. escape HTTP paths (recache method, and probably other places)
    * **NOTE:** this was not done. However, neither `recache(…)` nor `authenticatedPurchaseUrl(_:)` will be of use to us. We can still suggest it.
1. appropriately prefix remaining  category methods (Data, Dictionary etc)
1. scrutinize the code in `CardRanges.swift`
    * **NOTE:** Someone with more expertise should probably do this. There is no single list of BIN numbers. I found a couple discrepancies with Diner's club, and I certainly found plenty of cases that this list does not cover, but on the other hand, we/Stripe only cover a handful of cases.
1. refactor `ApplePayTests`, so that forced unwrapping is replaced by `XCTUnwrap()`
  * **NOTE:** This was discovered b/c the integration test fails due unsuccessful response from client `createPaymentMethodFrom(…)` method, due to `year is invalid` error. This error is most likely incorrect, and it is more likely that their certificate with  has expired. Either way, this test should be fixed.

Also

1. override default `description` and `debugDescription` methods to ensure internal contents are not accidentally logged.
2. It would be nice if `Transaction.errors` were not an optional array. Logic is simpler and more reliable if we can simply test for `transaction.errors.isEmpty == true`.